### PR TITLE
docs: README（英語・日本語）と LICENSE を追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 a2zime
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,101 @@
+[日本語](README_ja.md) | **English**
+
+# RSA-2048 IP
+
+A hardware IP core for RSA-2048 operations, targeting Xilinx Spartan-7 (XC7S25) and implemented in SystemVerilog.
+
+> **Note**: This implementation is for educational/learning purposes and does not guarantee cryptographic security for production use.
+
+---
+
+## Features
+
+- **Operations**: Encryption / Decryption / Signing / Verification (all reduced to modular exponentiation)
+- **Key length**: 2048 bit
+- **Algorithm**: FIOS Montgomery multiplication + Left-to-right binary Square-and-Multiply
+- **Optimization**: CRT (Chinese Remainder Theorem) for fast private-key operations
+- **Interface**: 32-bit serial Valid/Ready handshake
+- **DSP**: DSP48E1 × 1 (32×32 multiply-accumulate)
+- **Memory**: True Dual-Port BRAM36K × 1
+
+## Performance Estimate (100 MHz)
+
+| Operation | Estimated Time |
+|---|---|
+| Public-key (e=65537) | ~8.1 ms |
+| Private-key (CRT) | ~285 ms |
+
+## Resource Estimate (Spartan-7 XC7S25)
+
+| Resource | Estimated | Available | Utilization |
+|---|---|---|---|
+| LUT | ~4,000–6,000 | 14,600 | ~30–40% |
+| FF | ~2,000–3,000 | 29,200 | ~10% |
+| DSP48E1 | 1–2 | 45 | 2–4% |
+| BRAM36K | 1 | 30 | 3% |
+
+---
+
+## Directory Structure
+
+```
+rsa_2048/
+├── docs/               Documentation (requirements, design spec)
+│   └── img/            WaveDrom timing chart SVGs
+├── rtl/                RTL source (SystemVerilog)
+├── tb/                 Testbenches
+├── scripts/            Utility scripts
+├── common/             Shared coding style and dev-flow rules
+└── CLAUDE.md           Claude Code project instructions
+```
+
+## Module Hierarchy
+
+```
+rsa_top
+├── io_controller       32-bit serial I/O (Valid/Ready)
+├── mod_exp             Modular exponentiation (Square-and-Multiply)
+│   └── mont_mul        Montgomery multiplication (FIOS, 32-bit word)
+│       └── mul_add_unit  32×32 multiply-accumulate (DSP48E1 wrapper)
+├── crt_controller      CRT orchestration
+└── operand_mem         Dual-port BRAM operand storage
+```
+
+---
+
+## Development Status
+
+| Step | Status |
+|---|---|
+| Requirements definition | Done |
+| Design specification | Done |
+| RTL coding | Not started |
+| Verification specification | Not started |
+| Testbench & simulation | Not started |
+
+---
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| [Verible](https://github.com/chipsalliance/verible) | Lint & format |
+| [Icarus Verilog](http://iverilog.icarus.com/) | Simulation |
+| [Verilator](https://www.veripool.org/verilator/) | Fast simulation |
+| [GTKWave](https://gtkwave.sourceforge.net/) | Waveform viewer |
+
+```bash
+brew tap chipsalliance/verible
+brew install verible icarus-verilog verilator gtkwave gh
+```
+
+---
+
+## Documentation
+
+- [Requirements Specification](docs/requirements.md)
+- [Design Specification](docs/design_spec.md)
+
+## License
+
+MIT License — see [LICENSE](LICENSE) for details.

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,101 @@
+**日本語** | [English](README.md)
+
+# RSA-2048 IP
+
+RSA-2048 演算を行うハードウェア IP コア。Xilinx Spartan-7（XC7S25）をターゲットとし、SystemVerilog で実装する。
+
+> **Note**: 本実装は教育・学習目的であり、暗号ライブラリとしての安全性を保証するものではありません。
+
+---
+
+## 特徴
+
+- **対応演算**: 暗号化 / 復号 / 署名 / 検証（すべてモジュラー累乗に帰着）
+- **鍵長**: 2048 bit
+- **アルゴリズム**: FIOS モンゴメリ乗算 + Left-to-right binary Square-and-Multiply
+- **高速化**: CRT（中国剰余定理）による秘密鍵演算の高速化
+- **インターフェース**: 32bit シリアル Valid/Ready ハンドシェイク
+- **DSP**: DSP48E1 × 1（32×32 積和演算）
+- **メモリ**: デュアルポート BRAM36K × 1
+
+## 性能見積り（100 MHz）
+
+| 操作 | 推定時間 |
+|---|---|
+| 公開鍵演算（e=65537） | ~8.1 ms |
+| 秘密鍵演算（CRT） | ~285 ms |
+
+## リソース見積り（Spartan-7 XC7S25）
+
+| リソース | 使用見込み | 利用可能 | 使用率 |
+|---|---|---|---|
+| LUT | ~4,000–6,000 | 14,600 | ~30–40% |
+| FF | ~2,000–3,000 | 29,200 | ~10% |
+| DSP48E1 | 1–2 | 45 | 2–4% |
+| BRAM36K | 1 | 30 | 3% |
+
+---
+
+## ディレクトリ構成
+
+```
+rsa_2048/
+├── docs/               ドキュメント（要求仕様・設計仕様）
+│   └── img/            WaveDrom タイミングチャート SVG
+├── rtl/                RTL ソース（SystemVerilog）
+├── tb/                 テストベンチ
+├── scripts/            補助スクリプト
+├── common/             共通開発ルール・コーディング規約
+└── CLAUDE.md           Claude Code 向けプロジェクト指示
+```
+
+## モジュール階層
+
+```
+rsa_top
+├── io_controller       32bit シリアル I/O（Valid/Ready）
+├── mod_exp             モジュラー累乗（Square-and-Multiply）
+│   └── mont_mul        モンゴメリ乗算（FIOS, 32bit ワード）
+│       └── mul_add_unit  32×32 積和演算（DSP48E1 ラッパー）
+├── crt_controller      CRT オーケストレーション
+└── operand_mem         デュアルポート BRAM オペランドストレージ
+```
+
+---
+
+## 開発状況
+
+| 工程 | 状態 |
+|---|---|
+| 要求仕様定義 | 完了 |
+| 設計仕様作成 | 完了 |
+| RTL コーディング | 未着手 |
+| 検証仕様作成 | 未着手 |
+| テストベンチ実装 & シミュレーション | 未着手 |
+
+---
+
+## 使用ツール
+
+| ツール | 用途 |
+|---|---|
+| [Verible](https://github.com/chipsalliance/verible) | Lint・フォーマット |
+| [Icarus Verilog](http://iverilog.icarus.com/) | シミュレーション |
+| [Verilator](https://www.veripool.org/verilator/) | 高速シミュレーション |
+| [GTKWave](https://gtkwave.sourceforge.net/) | 波形確認 |
+
+```bash
+brew tap chipsalliance/verible
+brew install verible icarus-verilog verilator gtkwave gh
+```
+
+---
+
+## ドキュメント
+
+- [要求仕様書](docs/requirements.md)
+- [設計仕様書](docs/design_spec.md)
+
+## ライセンス
+
+MIT License — 詳細は [LICENSE](LICENSE) を参照。


### PR DESCRIPTION
## 変更内容
- `README.md`（英語）を追加 — プロジェクト概要・特徴・性能/リソース見積り・モジュール階層・開発状況・使用ツール・ドキュメントリンクを含む
- `README_ja.md`（日本語）を追加 — README.md と同内容の日本語版
- 各ファイル先頭に相互リンクを設置し、言語の切り替えが可能
- `LICENSE`（MIT License）を追加

## 完了確認
- [x] 工程の成果物が docs/ または rtl/ に揃っている
- [x] 前工程の成果物との整合性を確認済み（モジュール階層・性能見積りは設計仕様書と一致）
- [ ] （RTL工程のみ）Veribleによるlintクリア済み

## レビューポイント
- README の内容（特徴・性能・リソース）が設計仕様書と齟齬がないか
- 英語表現に不自然な箇所がないか