### PR TITLE
fix+test: io_controller unload バグ修正（#26）& テストベンチ実装（IO-01〜14）

### DIFF
--- a/docs/verification_result.md
+++ b/docs/verification_result.md
@@ -1,7 +1,7 @@
 # RSA-2048 IP 検証結果レポート
 
 **作成日**: 2026年5月2日
-**更新日**: 2026年5月6日
+**更新日**: 2026年5月10日
 **作成者**: a2zime × Claude Code
 **対応仕様書**: [verification_spec.md](verification_spec.md) v1.7
 **シミュレータ**: Icarus Verilog (iverilog -g2012)
@@ -17,7 +17,7 @@
 | `operand_mem` | `tb/tb_operand_mem.sv` | MEM-01〜09 | 32 / 32 | ✅ PASSED |
 | `mont_mul` | `tb/tb_mont_mul.sv` | MM-01〜16 | 1832 / 1832 | ✅ PASSED |
 | `mod_exp` | `tb/tb_mod_exp.sv` | ME-01〜16 | 1890 / 1890 | ✅ PASSED |
-| `io_controller` | — | IO-01〜14 | — | ⏳ 未着手 |
+| `io_controller` | `tb/tb_io_controller.sv` | IO-01〜14 | 1988 / 1988 | ✅ PASSED |
 | `crt_controller` | — | CRT-01〜12 | — | ⏳ 未着手 |
 | `rsa_top` | — | TOP-01〜16 | — | ⏳ 未着手 |
 
@@ -197,7 +197,58 @@ TEST PASSED  1890 / 1890 checks
 
 ---
 
-## 6. 発見済みバグ・仕様誤植
+## 6. io_controller 検証結果
+
+**シミュレーション実行コマンド:**
+```
+iverilog -g2012 -o sim_io.out rtl/rsa_pkg.sv rtl/operand_mem.sv rtl/io_controller.sv tb/tb_io_controller.sv
+vvp sim_io.out          # 通常実行（VCDなし）
+vvp sim_io.out +vcd     # デバッグ時のみ VCD 生成
+```
+
+**最終出力:**
+```
+TEST PASSED  1988 / 1988 checks
+```
+
+**テストデータ:** `$urandom`（seed は iverilog 既定）でテスト中に生成。Python 参照モデルは不要（io_controller はアドレッシングのみで値変換を伴わないため、TB 側で期待アドレス/データを直接構築できる）。
+
+**メモリモデル:** 実 RTL の `operand_mem` を TB に組み込み、Port A を DUT が駆動・Port B を TB が backdoor として使用（unload 用 result 領域の事前ロード）。
+
+### IO-01〜14 詳細
+
+| 検証ID | 検証内容 | 種別 | チェック数 | 結果 | 詳細 |
+|---|---|---|---|---|---|
+| IO-01 | 2048bit パラメータロード（ParamBase, 64 ワード） | 正常系 | 129 | ✅ PASS | 各サイクルで `mem_we_o=1`・`mem_addr_o=ADDR_BASE+i`・`mem_wdata_o=data_i[i]`、`load_done_o` パルス1回 |
+| IO-02 | 1024bit パラメータロード（ParamP, 32 ワード） | 正常系 | 65 | ✅ PASS | 32 ワード書込・最終ワードで `load_done_o` を1サイクル |
+| IO-03 | 32bit パラメータロード（ParamNPrime, 1 ワード） | 正常系 | 3 | ✅ PASS | 1 サイクルで `load_done_o` を1パルス |
+| IO-04 | 全 16 ParamID マッピング網羅 | 正常系 | 1110 | ✅ PASS | `param_addr_e` 全 16 値（ParamBase〜ParamBasQ）を順に投入。各 ID のベースアドレス・転送ワード数が `rsa_pkg` 定数と一致 |
+| IO-05 | LSB-first 順序 | 機能 | 129 | ✅ PASS | ParamBase に 64 ワード書込後、Port B 経由で `mem[ADDR_BASE+0]==w0` を確認 |
+| IO-06 | `load_done_o` パルス幅 = 1 サイクル | プロトコル | 129 | ✅ PASS | ParamMod 64 ワード書込中、`load_done_o=1` のサイクル数がちょうど 1 |
+| IO-07 | unload 64 ワード（ADDR_RESULT） | 正常系 | 65 | ✅ PASS | Port B で 64 ワード事前ロード後 unload。`data_o` 列が事前ロード値と bit-exact 一致、`unload_done_o` パルス1回 |
+| IO-08 | unload は addr_i に依らず 64 ワード（実装意図） | 機能 | 65 | ✅ PASS | `addr_i=ParamP` でも 64 ワードを `ADDR_RESULT` から出力（設計仕様 §4.2 に基づく実装意図確認） |
+| IO-09 | `valid_i=0` 期間中は word_cnt 進行しない | プロトコル | 17 | ✅ PASS | StIoLoad 中に `valid_i=0` を 8 サイクル維持。期間中 `mem_we_o=0`・`mem_addr_o` 不変・`load_done_o=0` |
+| IO-10 | `ready_i=0` バックプレッシャ保持 | プロトコル | 14 | ✅ PASS | unload 中に `ready_i=0` を 7 サイクル維持。期間中 `valid_o=1`・`data_o` 不変。再開後 `unload_done_o` 正常パルス |
+| IO-11 | 連続パラメータロード（ParamBase → ParamP） | 機能 | 194 | ✅ PASS | ParamBase 64 ワード後 ParamP 32 ワードを連続投入。両領域の最終ワードが書込値と一致（領域干渉なし） |
+| IO-12 | リセット中の `load_en_i` 無視 | 異常系 | 1 | ✅ PASS | `rst_n=0` 中に `load_en_i=valid_i=1` を 8 サイクル維持。`mem_we_o` は一度も立たず |
+| IO-13 | 全 4bit `addr_i` が有効値（IO-04 で網羅、ParamBasQ 単独確認） | 異常系 | 65 | ✅ PASS | `param_addr_e` 全 16 値が有効。ParamBasQ（4'hF）で 32 ワードロードが正常完了 |
+| IO-14 | `load_en_i` と `unload_en_i` 同時アサート → load 優先 | プロトコル | 2 | ✅ PASS | 両 enable を 1 サイクル同時アサート。`mem_we_o` パルスを観測（load 経路）、`valid_o=0`（unload 経路は engaged せず） |
+
+**チェック数内訳:** IO-01(129) + IO-02(65) + IO-03(3) + IO-04(1110) + IO-05(129) + IO-06(129) + IO-07(65) + IO-08(65) + IO-09(17) + IO-10(14) + IO-11(194) + IO-12(1) + IO-13(65) + IO-14(2) = **1988**
+
+### 発見バグ（io_controller unload パイプライン 1件）
+
+テストベンチ実装中に RTL バグ 1件を発見・修正（Issue #26）。
+
+| Issue | バグ内容 | 症状 |
+|---|---|---|
+| [#26](https://github.com/a2zime/rsa_2048/issues/26) | unload パイプラインで `unload_data_q` が毎サイクル `mem_rdata_i` で上書き、`mem_addr_o` が出力カウンタ `word_cnt_q` で生成されるため BRAM 1cyc レイテンシと整合せず | 最初のワードが 3 回連続出力され末尾 2 ワードが消失 |
+
+**修正方針:** 読み出し用 `read_cnt_q` を出力カウンタから分離し、`mem_re_q`（前サイクル発行フラグ）でスキッド更新を制御。スキッドが空 or 出力受領時のみ次の読み出しを発行することで、in-flight データ取りこぼしを防止。throughput は 1 ワード/2 サイクルになるが、io_controller は外部 I/O 律速のため許容（64 ワード unload で約 130 サイクル）。
+
+---
+
+## 7. 発見済みバグ・仕様誤植
 
 | Issue | 種別 | 内容 | 対応状況 |
 |---|---|---|---|
@@ -211,13 +262,13 @@ TEST PASSED  1890 / 1890 checks
 | [#22](https://github.com/a2zime/rsa_2048/issues/22) | RTL バグ | `rtl/mod_exp.sv` `StExpScan` — 指数ワード読み出しが1サイクル早く誤データをキャプチャ | sub=2 を追加して2サイクルラテンシに合わせる |
 | [#23](https://github.com/a2zime/rsa_2048/issues/23) | RTL バグ | `rtl/mod_exp.sv` `StExpDone` — 最終ワード書込が `me_busy=0` 遷移で Port A mux に遮断 | sub=3（flush）を追加し書込完了まで `me_busy=1` を保持 |
 | [#24](https://github.com/a2zime/rsa_2048/issues/24) | RTL バグ | `rtl/mod_exp.sv` `StExpInitRWait` — `bit_cnt` 初期値が1小さく MSB スキップ | `bit_cnt = bit_width` に変更（`bit_width-1` から） |
+| [#26](https://github.com/a2zime/rsa_2048/issues/26) | RTL バグ | `rtl/io_controller.sv` unload パイプライン — `unload_data_q` 上書き＆出力カウンタによるアドレス生成で BRAM レイテンシと整合せず最初のワードが3回出力 | 読み出しカウンタ `read_cnt_q` 分離・`mem_re_q` ベースのスキッド更新に変更。throughput は 1 word / 2 cycles |
 
 ---
 
-## 7. 未着手モジュールの検証計画
+## 8. 未着手モジュールの検証計画
 
 | モジュール | 検証ID | 概要 | 依存関係 |
 |---|---|---|---|
-| `io_controller` | IO-01〜14 | パラメータロード・アンロード、Valid/Ready | — |
 | `crt_controller` | CRT-01〜12 | CRT 復号フロー全体 | `mod_exp` + `mont_mul` |
 | `rsa_top` | TOP-01〜16 | 統合テスト（暗号化・復号・署名・検証） | 全モジュール |

--- a/rtl/io_controller.sv
+++ b/rtl/io_controller.sv
@@ -41,8 +41,13 @@ module io_controller #(
 
   io_state_e state_d, state_q;
 
-  // Word counter
+  // Word counter (output side: advances on (valid_i & ready_o) for Load,
+  // and on (valid_o & ready_i) for Unload)
   logic [6:0] word_cnt_d, word_cnt_q;
+
+  // Read-address counter for Unload (separate from word_cnt_q so the read
+  // pipeline can lead the output handshake by 1 cycle for BRAM latency)
+  logic [6:0] read_cnt_d, read_cnt_q;
 
   // Number of words to transfer
   logic [6:0] num_xfer_words;
@@ -104,13 +109,18 @@ module io_controller #(
   assign unload_num_words = 7'd64;
 
   // Read pipeline for Unload (handles 1-cycle BRAM read latency)
+  // unload_read_valid_q: skid (unload_data_q) holds an unconsumed word
+  // mem_re_q:            mem_re_o was asserted in the previous cycle
+  //                      (a read fired and its data is on mem_rdata_i now)
   logic unload_read_valid_q;
+  logic mem_re_q;
   logic [WordWidth-1:0] unload_data_q;
 
   // Combinational logic
   always_comb begin
     state_d    = state_q;
     word_cnt_d = word_cnt_q;
+    read_cnt_d = read_cnt_q;
 
     unique case (state_q)
       StIoIdle: begin
@@ -119,6 +129,7 @@ module io_controller #(
           state_d    = StIoLoad;
         end else if (unload_en_i) begin
           word_cnt_d = '0;
+          read_cnt_d = '0;
           state_d    = StIoUnload;
         end
       end
@@ -143,6 +154,9 @@ module io_controller #(
             word_cnt_d = word_cnt_q + 7'd1;
           end
         end
+        if (mem_re_o) begin
+          read_cnt_d = read_cnt_q + 7'd1;
+        end
       end
 
       default: state_d = StIoIdle;
@@ -152,18 +166,31 @@ module io_controller #(
   // Sequential logic
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      state_q    <= StIoIdle;
-      word_cnt_q <= '0;
+      state_q             <= StIoIdle;
+      word_cnt_q          <= '0;
+      read_cnt_q          <= '0;
+      mem_re_q            <= 1'b0;
       unload_read_valid_q <= 1'b0;
-      unload_data_q <= '0;
+      unload_data_q       <= '0;
     end else begin
       state_q    <= state_d;
       word_cnt_q <= word_cnt_d;
+      read_cnt_q <= read_cnt_d;
+      mem_re_q   <= mem_re_o;
 
-      // Read pipeline for Unload
+      // Skid update for Unload:
+      //   - Capture mem_rdata_i into unload_data_q only when a read fired in
+      //     the previous cycle (mem_re_q) AND the skid has space (either empty
+      //     or being drained this cycle by a successful output handshake).
+      //   - Otherwise, if the consumer takes the current word, mark the skid
+      //     empty so the next read can fill it.
       if (state_q == StIoUnload) begin
-        unload_read_valid_q <= mem_re_o;
-        unload_data_q <= mem_rdata_i;
+        if (mem_re_q && (!unload_read_valid_q || (valid_o && ready_i))) begin
+          unload_data_q       <= mem_rdata_i;
+          unload_read_valid_q <= 1'b1;
+        end else if (valid_o && ready_i) begin
+          unload_read_valid_q <= 1'b0;
+        end
       end else begin
         unload_read_valid_q <= 1'b0;
       end
@@ -177,11 +204,19 @@ module io_controller #(
   assign mem_we_o    = (state_q == StIoLoad) && valid_i && ready_o;
   assign mem_addr_o  = (state_q == StIoLoad)
                      ? (param_base_addr + {3'b0, word_cnt_q})
-                     : (unload_base_addr + {3'b0, word_cnt_q});
+                     : (unload_base_addr + {3'b0, read_cnt_q});
   assign mem_wdata_o = data_i;
-  assign mem_re_o    = (state_q == StIoUnload) && (!unload_read_valid_q || ready_i);
+  // Issue a read only when:
+  //   - State is Unload and we still have words to fetch
+  //   - The previous cycle did NOT issue a read (avoid double in-flight, since
+  //     the skid is 1-deep and in-flight data would be dropped)
+  //   - Skid is empty or being drained this cycle
+  assign mem_re_o    = (state_q == StIoUnload)
+                    && (read_cnt_q < unload_num_words)
+                    && !mem_re_q
+                    && (!unload_read_valid_q || (valid_o && ready_i));
 
-  // Unload: output data read from memory
+  // Unload: output data read from memory (registered into unload_data_q)
   assign valid_o = (state_q == StIoUnload) && unload_read_valid_q;
   assign data_o  = unload_data_q;
 

--- a/tb/tb_io_controller.sv
+++ b/tb/tb_io_controller.sv
@@ -1,0 +1,728 @@
+// Description: Testbench for io_controller (IO-01..IO-14 from verification_spec.md §5.4)
+//   Instantiates io_controller + operand_mem.
+//   Port A は DUT が駆動。Port B は TB が backdoor で結果領域に事前ロードするのに使う。
+`timescale 1ns / 1ps
+
+module tb_io_controller;
+
+  import rsa_pkg::*;
+
+  // -----------------------------------------------------------------
+  // Parameters
+  // -----------------------------------------------------------------
+  localparam int CLK_HALF = 5;  // 100 MHz
+  localparam int MAX_CYCLES = 200_000;  // safety cap
+
+  // -----------------------------------------------------------------
+  // Clock / reset
+  // -----------------------------------------------------------------
+  logic clk, rst_n;
+  initial clk = 1'b0;
+  always #CLK_HALF clk = ~clk;
+
+  // VCD opt-in (pass +vcd to vvp)
+  initial begin
+    if ($test$plusargs("vcd")) begin
+      $dumpfile("tb_io_controller.vcd");
+      $dumpvars(0, tb_io_controller);
+    end
+  end
+
+  // Global timeout
+  int cycle_cnt;
+  always @(posedge clk) begin
+    cycle_cnt <= cycle_cnt + 1;
+    if (cycle_cnt > MAX_CYCLES) begin
+      $fatal(1, "TIMEOUT after %0d cycles", MAX_CYCLES);
+    end
+  end
+
+  // -----------------------------------------------------------------
+  // DUT signals
+  // -----------------------------------------------------------------
+  logic        valid_i, ready_o;
+  logic [3:0]  addr_i;
+  logic [31:0] data_i;
+  logic        valid_o;
+  logic        ready_i;
+  logic [31:0] data_o;
+  logic        load_en_i, unload_en_i;
+  logic        load_done_o, unload_done_o;
+
+  // Memory interface (Port A: DUT)
+  logic        mem_we;
+  logic [9:0]  mem_addr;
+  logic [31:0] mem_wdata, mem_rdata;
+  logic        mem_re;
+
+  // Memory interface (Port B: TB backdoor)
+  logic        b_we;
+  logic [9:0]  b_addr;
+  logic [31:0] b_wdata, b_rdata;
+
+  io_controller dut (
+    .clk_i        (clk),
+    .rst_ni       (rst_n),
+    .valid_i      (valid_i),
+    .ready_o      (ready_o),
+    .addr_i       (addr_i),
+    .data_i       (data_i),
+    .valid_o      (valid_o),
+    .ready_i      (ready_i),
+    .data_o       (data_o),
+    .mem_we_o     (mem_we),
+    .mem_addr_o   (mem_addr),
+    .mem_wdata_o  (mem_wdata),
+    .mem_rdata_i  (mem_rdata),
+    .mem_re_o     (mem_re),
+    .load_en_i    (load_en_i),
+    .unload_en_i  (unload_en_i),
+    .load_done_o  (load_done_o),
+    .unload_done_o(unload_done_o)
+  );
+
+  operand_mem u_mem (
+    .clk_i    (clk),
+    .rst_ni   (rst_n),
+    .a_we_i   (mem_we),
+    .a_addr_i (mem_addr),
+    .a_wdata_i(mem_wdata),
+    .a_rdata_o(mem_rdata),
+    .b_we_i   (b_we),
+    .b_addr_i (b_addr),
+    .b_wdata_i(b_wdata),
+    .b_rdata_o(b_rdata)
+  );
+
+  // -----------------------------------------------------------------
+  // Counters
+  // -----------------------------------------------------------------
+  int err_cnt;
+  int check_cnt;
+
+  // -----------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------
+  function automatic logic [9:0] expected_base(input [3:0] aid);
+    case (aid)
+      ParamBase:   expected_base = ADDR_BASE[9:0];
+      ParamExp:    expected_base = ADDR_EXP[9:0];
+      ParamMod:    expected_base = ADDR_MOD[9:0];
+      ParamRSq:    expected_base = ADDR_RSQ[9:0];
+      ParamNPrime: expected_base = 10'h000;  // register-held in real system
+      ParamP:      expected_base = ADDR_P[9:0];
+      ParamQ:      expected_base = ADDR_Q[9:0];
+      ParamDp:     expected_base = ADDR_DP[9:0];
+      ParamDq:     expected_base = ADDR_DQ[9:0];
+      ParamQinv:   expected_base = ADDR_QINV[9:0];
+      ParamRSqP:   expected_base = ADDR_RSQ_P[9:0];
+      ParamRSqQ:   expected_base = ADDR_RSQ_Q[9:0];
+      ParamNpP:    expected_base = 10'h000;  // register-held
+      ParamNqP:    expected_base = 10'h000;  // register-held
+      ParamBasP:   expected_base = ADDR_BASE_P[9:0];
+      ParamBasQ:   expected_base = ADDR_BASE_Q[9:0];
+      default:     expected_base = 10'h000;
+    endcase
+  endfunction
+
+  function automatic int expected_n(input [3:0] aid);
+    case (aid)
+      ParamBase, ParamExp, ParamMod, ParamRSq:
+        expected_n = 64;
+      ParamNPrime, ParamNpP, ParamNqP:
+        expected_n = 1;
+      default:
+        expected_n = 32;
+    endcase
+  endfunction
+
+  // -----------------------------------------------------------------
+  // Initial driver values
+  // -----------------------------------------------------------------
+  task automatic init_signals;
+    valid_i = 1'b0;
+    addr_i  = 4'h0;
+    data_i  = 32'h0;
+    ready_i = 1'b0;
+    load_en_i = 1'b0;
+    unload_en_i = 1'b0;
+    b_we = 1'b0;
+    b_addr = 10'h0;
+    b_wdata = 32'h0;
+    err_cnt = 0;
+    check_cnt = 0;
+    cycle_cnt = 0;
+  endtask
+
+  task automatic do_reset;
+    rst_n = 1'b0;
+    repeat (4) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  endtask
+
+  // ============================================================
+  // Load helper:
+  //   Pulses load_en_i for 1 cycle, then drives n words back-to-back
+  //   with valid_i held high. Verifies on each accepted handshake:
+  //     mem_we_o  == 1
+  //     mem_addr_o == base + i
+  //     mem_wdata_o == data_i (the value just driven)
+  //   Returns the captured load_done pulse count and last-word pulse cycle.
+  // ============================================================
+  task automatic do_load(
+    input [3:0] aid,
+    input int n,
+    output logic [31:0] data_arr [],
+    output int          load_done_pulses,
+    output int          load_done_high_cycles
+  );
+    logic [9:0] base_addr;
+    base_addr = expected_base(aid);
+    data_arr = new[n];
+    load_done_pulses = 0;
+    load_done_high_cycles = 0;
+
+    // Issue load_en_i for one cycle
+    @(negedge clk);
+    addr_i    = aid;
+    load_en_i = 1'b1;
+    @(negedge clk);
+    load_en_i = 1'b0;
+    // After this negedge, the next posedge sampled state_q == StIoLoad
+
+    // Drive n words; on each negedge present (valid_i, data_i)
+    // Sampling on posedge confirms the write.
+    for (int i = 0; i < n; i++) begin
+      data_arr[i] = $urandom();
+      @(negedge clk);
+      valid_i = 1'b1;
+      data_i  = data_arr[i];
+
+      // Sample at posedge
+      @(posedge clk);
+      // ready_o must be high during StIoLoad
+      if (ready_o !== 1'b1) begin
+        $error("IO load[%0d]: ready_o=%b expected 1 (aid=%0d)", i, ready_o, aid);
+        err_cnt++;
+      end
+      check_cnt++;
+
+      // Memory write must happen
+      if (mem_we !== 1'b1) begin
+        $error("IO load[%0d]: mem_we_o=%b expected 1 (aid=%0d)", i, mem_we, aid);
+        err_cnt++;
+      end else if (mem_addr !== base_addr + i[9:0]) begin
+        $error("IO load[%0d]: mem_addr_o=%h expected %h (aid=%0d)",
+               i, mem_addr, base_addr + i[9:0], aid);
+        err_cnt++;
+      end else if (mem_wdata !== data_arr[i]) begin
+        $error("IO load[%0d]: mem_wdata_o=%h expected %h (aid=%0d)",
+               i, mem_wdata, data_arr[i], aid);
+        err_cnt++;
+      end else begin
+        check_cnt++;
+      end
+
+      // Track load_done timing
+      if (load_done_o) begin
+        load_done_pulses++;
+        if (i == n - 1) begin
+          load_done_high_cycles = 1;
+        end else begin
+          $error("IO load[%0d]: load_done_o asserted before last word (n=%0d)", i, n);
+          err_cnt++;
+        end
+      end
+    end
+
+    // Drop valid_i; load_done should drop within 1 cycle
+    @(negedge clk);
+    valid_i = 1'b0;
+    data_i  = 32'h0;
+    @(posedge clk);
+    if (load_done_o) begin
+      load_done_high_cycles++;
+    end
+  endtask
+
+  // ============================================================
+  // Backdoor write of 64 words to ADDR_RESULT via Port B
+  //   入力は dynamic array で受ける（iverilog 制限により unpacked-dim 引数は不可）
+  // ============================================================
+  task automatic prefill_result(input logic [31:0] data_arr []);
+    @(negedge clk);
+    for (int i = 0; i < 64; i++) begin
+      b_we    = 1'b1;
+      b_addr  = ADDR_RESULT[9:0] + i[9:0];
+      b_wdata = data_arr[i];
+      @(negedge clk);
+    end
+    b_we    = 1'b0;
+    b_addr  = 10'h0;
+    b_wdata = 32'h0;
+    @(posedge clk);  // settle
+  endtask
+
+  // ============================================================
+  // Unload helper:
+  //   Pulses unload_en_i with addr_i=aid; captures `n` words from data_o
+  //   when (valid_o & ready_i). ready_i is held high for the full duration.
+  //   Returns the captured stream and unload_done pulse count.
+  // ============================================================
+  task automatic do_unload(
+    input [3:0] aid,
+    input int n,
+    output logic [31:0] data_arr [],
+    output int          unload_done_pulses
+  );
+    int captured;
+    int waitcnt;
+    data_arr = new[n];
+    captured = 0;
+    waitcnt  = 0;
+    unload_done_pulses = 0;
+
+    @(negedge clk);
+    addr_i      = aid;
+    unload_en_i = 1'b1;
+    ready_i     = 1'b1;
+    @(negedge clk);
+    unload_en_i = 1'b0;
+
+    while (captured < n) begin
+      @(posedge clk);
+      if (valid_o && ready_i) begin
+        data_arr[captured] = data_o;
+        captured++;
+      end
+      if (unload_done_o) unload_done_pulses++;
+      waitcnt++;
+      if (waitcnt > 5 * n + 50) begin
+        $error("IO unload: timeout, captured=%0d / expected=%0d", captured, n);
+        err_cnt++;
+        break;
+      end
+    end
+
+    @(negedge clk);
+    ready_i = 1'b0;
+  endtask
+
+  // ============================================================
+  // Test cases
+  // ============================================================
+
+  // IO-01: 2048bit パラメータロード（ParamBase, 64 words）
+  task automatic test_io_01;
+    logic [31:0] sent [];
+    int dones, done_high;
+    $display("---- IO-01: 2048bit Load (ParamBase, 64 words) ----");
+    do_load(ParamBase, 64, sent, dones, done_high);
+    if (dones != 1) begin
+      $error("IO-01: load_done pulse count = %0d (expected 1)", dones);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-02: 1024bit パラメータロード（ParamP, 32 words）
+  task automatic test_io_02;
+    logic [31:0] sent [];
+    int dones, done_high;
+    $display("---- IO-02: 1024bit Load (ParamP, 32 words) ----");
+    do_load(ParamP, 32, sent, dones, done_high);
+    if (dones != 1) begin
+      $error("IO-02: load_done pulse count = %0d (expected 1)", dones);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-03: 32bit パラメータロード（ParamNPrime, 1 word）
+  task automatic test_io_03;
+    logic [31:0] sent [];
+    int dones, done_high;
+    $display("---- IO-03: 32bit Load (ParamNPrime, 1 word) ----");
+    do_load(ParamNPrime, 1, sent, dones, done_high);
+    if (dones != 1) begin
+      $error("IO-03: load_done pulse count = %0d (expected 1)", dones);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-04: 全16 ParamID のアドレスマッピング検証
+  task automatic test_io_04;
+    logic [31:0] sent [];
+    int dones, done_high;
+    int n;
+    logic [9:0] base;
+    $display("---- IO-04: All 16 ParamIDs base/N mapping ----");
+    for (int aid = 0; aid < 16; aid++) begin
+      n    = expected_n(aid[3:0]);
+      base = expected_base(aid[3:0]);
+      do_load(aid[3:0], n, sent, dones, done_high);
+      if (dones != 1) begin
+        $error("IO-04 aid=%0d: load_done pulses=%0d expected 1", aid, dones);
+        err_cnt++;
+      end else check_cnt++;
+      // wait a cycle to ensure idle
+      @(posedge clk);
+    end
+  endtask
+
+  // IO-05: LSB-first 順序 — IO-01 で実質確認済み（w0 が base+0 に書かれること）
+  task automatic test_io_05;
+    logic [31:0] sent [];
+    int dones, done_high;
+    $display("---- IO-05: LSB-first ordering (w0 -> base+0) ----");
+    do_load(ParamBase, 64, sent, dones, done_high);
+    // Re-verify by reading mem[ADDR_BASE+0] via Port B and comparing to sent[0]
+    @(negedge clk);
+    b_we    = 1'b0;
+    b_addr  = ADDR_BASE[9:0];
+    @(posedge clk);
+    @(posedge clk);
+    if (b_rdata !== sent[0]) begin
+      $error("IO-05: mem[ADDR_BASE+0]=%h expected %h (w0)", b_rdata, sent[0]);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-06: load_done パルス幅 = 1 サイクル
+  task automatic test_io_06;
+    logic [31:0] sent [];
+    int dones, done_high;
+    $display("---- IO-06: load_done is 1-cycle pulse ----");
+    do_load(ParamMod, 64, sent, dones, done_high);
+    if (done_high != 1) begin
+      $error("IO-06: load_done_o asserted for %0d cycles (expected exactly 1)", done_high);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-07: unload 2048bit
+  task automatic test_io_07;
+    logic [31:0] expect_arr [];
+    logic [31:0] got [];
+    int dones;
+    $display("---- IO-07: Unload 64 words from ADDR_RESULT ----");
+    expect_arr = new[64];
+    for (int i = 0; i < 64; i++) expect_arr[i] = $urandom();
+    prefill_result(expect_arr);
+    do_unload(ParamBase, 64, got, dones);
+    for (int i = 0; i < 64; i++) begin
+      if (got[i] !== expect_arr[i]) begin
+        $error("IO-07[%0d]: data_o=%h expected %h", i, got[i], expect_arr[i]);
+        err_cnt++;
+      end else check_cnt++;
+    end
+    if (dones != 1) begin
+      $error("IO-07: unload_done pulses=%0d (expected 1)", dones);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-08: unload は addr_i に依らず 64 words 出力（実装意図確認）
+  //   仕様 v1.x には「N=32」と書かれているが、設計仕様 §4.2 と RTL の
+  //   `unload_num_words = 7'd64` 固定により unload は常に 64 ワード。
+  //   addr_i=ParamP を投入しても 64 ワード出力されることを検証する。
+  task automatic test_io_08;
+    logic [31:0] expect_arr [];
+    logic [31:0] got [];
+    int dones;
+    $display("---- IO-08: Unload always emits 64 words regardless of addr_i ----");
+    expect_arr = new[64];
+    for (int i = 0; i < 64; i++) expect_arr[i] = $urandom();
+    prefill_result(expect_arr);
+    do_unload(ParamP, 64, got, dones);
+    for (int i = 0; i < 64; i++) begin
+      if (got[i] !== expect_arr[i]) begin
+        $error("IO-08[%0d]: data_o=%h expected %h", i, got[i], expect_arr[i]);
+        err_cnt++;
+      end else check_cnt++;
+    end
+    if (dones != 1) begin
+      $error("IO-08: unload_done pulses=%0d (expected 1)", dones);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-09: ready_o 制御 — valid_i=0 の期間 word_cnt は進行しない
+  //   StIoLoad 中に valid_i を deassert し、その間 mem_we_o=0 かつ
+  //   mem_addr_o が同じアドレスを保持していることを確認。
+  task automatic test_io_09;
+    logic [31:0] sent [64];
+    logic [9:0]  addr_before;
+    int dones_before;
+    $display("---- IO-09: word_cnt halts while valid_i=0 ----");
+    // start load
+    @(negedge clk);
+    addr_i    = ParamBase;
+    load_en_i = 1'b1;
+    @(negedge clk);
+    load_en_i = 1'b0;
+    // drive 5 words then pause
+    for (int i = 0; i < 5; i++) begin
+      sent[i] = $urandom();
+      @(negedge clk);
+      valid_i = 1'b1;
+      data_i  = sent[i];
+      @(posedge clk);
+    end
+    // pause: valid_i=0 for 8 cycles
+    @(negedge clk);
+    valid_i = 1'b0;
+    data_i  = 32'h0;
+    @(posedge clk);
+    addr_before = mem_addr;
+    dones_before = 0;
+    for (int j = 0; j < 8; j++) begin
+      @(posedge clk);
+      if (mem_we !== 1'b0) begin
+        $error("IO-09: mem_we_o asserted while valid_i=0 (cycle %0d)", j);
+        err_cnt++;
+      end else check_cnt++;
+      if (mem_addr !== addr_before) begin
+        $error("IO-09: mem_addr_o changed during pause (got=%h expected=%h)",
+               mem_addr, addr_before);
+        err_cnt++;
+      end else check_cnt++;
+      if (load_done_o) dones_before++;
+    end
+    if (dones_before != 0) begin
+      $error("IO-09: load_done_o asserted during pause (count=%0d)", dones_before);
+      err_cnt++;
+    end else check_cnt++;
+    // resume and finish
+    for (int i = 5; i < 64; i++) begin
+      sent[i] = $urandom();
+      @(negedge clk);
+      valid_i = 1'b1;
+      data_i  = sent[i];
+      @(posedge clk);
+    end
+    @(negedge clk);
+    valid_i = 1'b0;
+    data_i  = 32'h0;
+  endtask
+
+  // IO-10: ready_i バックプレッシャ — ready_i=0 期間 valid_o & data_o 保持
+  //   1-deep skid（throughput 1 word / 2 cycles）に合わせて、
+  //   「valid_o=1 を観測してから ready_i=0 にする」ことで未受領のワードを
+  //   ホールドさせ、その期間 valid_o と data_o が保持されることを確認する。
+  task automatic test_io_10;
+    logic [31:0] expect_arr [];
+    logic [31:0] holdval;
+    int dones;
+    int got;
+    $display("---- IO-10: ready_i backpressure holds valid_o and data_o ----");
+    expect_arr = new[64];
+    for (int i = 0; i < 64; i++) expect_arr[i] = $urandom();
+    prefill_result(expect_arr);
+
+    // start unload
+    @(negedge clk);
+    addr_i      = ParamBase;
+    unload_en_i = 1'b1;
+    ready_i     = 1'b1;
+    @(negedge clk);
+    unload_en_i = 1'b0;
+
+    // accept first 3 words
+    got = 0;
+    while (got < 3) begin
+      @(posedge clk);
+      if (valid_o && ready_i) got++;
+    end
+
+    // Deassert ready_i FIRST, then wait for the next valid_o.
+    // The 4th word will sit in the skid (since ready_i=0) and be held there.
+    @(negedge clk);
+    ready_i = 1'b0;
+    while (!valid_o) @(posedge clk);
+    holdval = data_o;
+    if (valid_o !== 1'b1) begin
+      $error("IO-10: valid_o dropped at start of backpressure");
+      err_cnt++;
+    end else check_cnt++;
+    for (int j = 0; j < 6; j++) begin
+      @(posedge clk);
+      if (valid_o !== 1'b1) begin
+        $error("IO-10: valid_o dropped during ready_i=0 (cycle %0d)", j);
+        err_cnt++;
+      end else check_cnt++;
+      if (data_o !== holdval) begin
+        $error("IO-10: data_o changed during ready_i=0 (cycle %0d, got=%h held=%h)",
+               j, data_o, holdval);
+        err_cnt++;
+      end else check_cnt++;
+    end
+
+    // resume and drain
+    @(negedge clk);
+    ready_i = 1'b1;
+    dones = 0;
+    while (!unload_done_o) begin
+      @(posedge clk);
+      if (unload_done_o) dones++;
+    end
+    @(negedge clk);
+    ready_i = 1'b0;
+    if (dones != 1) begin
+      $error("IO-10: unload_done_o not pulsed after resume (count=%0d)", dones);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-11: 連続パラメータロード（ParamBase → ParamP）
+  task automatic test_io_11;
+    logic [31:0] sent_a [];
+    logic [31:0] sent_b [];
+    int dones, done_high;
+    logic [31:0] readback;
+    $display("---- IO-11: Continuous param loads (ParamBase then ParamP) ----");
+    do_load(ParamBase, 64, sent_a, dones, done_high);
+    if (dones != 1) begin err_cnt++; $error("IO-11: ParamBase load_done count=%0d", dones); end
+    do_load(ParamP, 32, sent_b, dones, done_high);
+    if (dones != 1) begin err_cnt++; $error("IO-11: ParamP load_done count=%0d", dones); end
+
+    // Verify ParamBase region preserved (last word)
+    @(negedge clk);
+    b_we    = 1'b0;
+    b_addr  = ADDR_BASE[9:0] + 10'd63;
+    @(posedge clk);
+    @(posedge clk);
+    readback = b_rdata;
+    if (readback !== sent_a[63]) begin
+      $error("IO-11: mem[ADDR_BASE+63]=%h expected %h (corrupted by ParamP load?)",
+             readback, sent_a[63]);
+      err_cnt++;
+    end else check_cnt++;
+
+    // Verify ParamP region (last word)
+    @(negedge clk);
+    b_addr  = ADDR_P[9:0] + 10'd31;
+    @(posedge clk);
+    @(posedge clk);
+    readback = b_rdata;
+    if (readback !== sent_b[31]) begin
+      $error("IO-11: mem[ADDR_P+31]=%h expected %h", readback, sent_b[31]);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-12: rst_n=0 中の load_en_i は無視され、mem_we_o は立たない
+  task automatic test_io_12;
+    int rst_violations;
+    $display("---- IO-12: load_en during reset must not assert mem_we_o ----");
+    rst_violations = 0;
+    @(negedge clk);
+    rst_n     = 1'b0;
+    addr_i    = ParamBase;
+    load_en_i = 1'b1;
+    valid_i   = 1'b1;
+    data_i    = 32'hDEAD_BEEF;
+    for (int j = 0; j < 8; j++) begin
+      @(posedge clk);
+      if (mem_we !== 1'b0) rst_violations++;
+    end
+    @(negedge clk);
+    rst_n     = 1'b1;
+    load_en_i = 1'b0;
+    valid_i   = 1'b0;
+    data_i    = 32'h0;
+    addr_i    = 4'h0;
+    if (rst_violations != 0) begin
+      $error("IO-12: mem_we_o asserted during reset (%0d cycles)", rst_violations);
+      err_cnt++;
+    end else check_cnt++;
+    @(posedge clk);
+  endtask
+
+  // IO-13: 4bit param_addr は全 16 値が有効。default 経路は通常動作中に到達しない。
+  //   IO-04 で全 16 値のマッピングを確認済みのため、本ケースは default の安全動作
+  //   （base=0, n=1 と等価）を addr_i=4'hF で別途確認する。
+  task automatic test_io_13;
+    logic [31:0] sent [];
+    int dones, done_high;
+    $display("---- IO-13: All 4-bit addr_i values are valid (covered by IO-04) ----");
+    // ParamBasQ (4'hF) is the largest enum; verify it does not regress
+    do_load(ParamBasQ, 32, sent, dones, done_high);
+    if (dones != 1) begin
+      $error("IO-13: ParamBasQ load_done pulses=%0d", dones);
+      err_cnt++;
+    end else check_cnt++;
+  endtask
+
+  // IO-14: load_en_i と unload_en_i 同時アサート → load 優先（RTL の if/else if 順）
+  task automatic test_io_14;
+    int load_writes;
+    $display("---- IO-14: load_en + unload_en simultaneous -> load takes priority ----");
+    load_writes = 0;
+    @(negedge clk);
+    addr_i      = ParamBase;
+    load_en_i   = 1'b1;
+    unload_en_i = 1'b1;
+    valid_i     = 1'b1;
+    data_i      = 32'hCAFE_F00D;
+    @(negedge clk);
+    load_en_i   = 1'b0;
+    unload_en_i = 1'b0;
+    // Drive a few words; expect mem_we to assert (load path)
+    for (int i = 0; i < 4; i++) begin
+      data_i = $urandom();
+      @(posedge clk);
+      if (mem_we) load_writes++;
+    end
+    @(negedge clk);
+    valid_i = 1'b0;
+    data_i  = 32'h0;
+    if (load_writes < 1) begin
+      $error("IO-14: no mem_we_o pulse observed (load did not take priority)");
+      err_cnt++;
+    end else check_cnt++;
+    if (valid_o !== 1'b0) begin
+      $error("IO-14: valid_o asserted (unload path engaged unexpectedly)");
+      err_cnt++;
+    end else check_cnt++;
+    // Drain any remaining state by waiting until DUT goes idle
+    repeat (4) @(posedge clk);
+  endtask
+
+  // -----------------------------------------------------------------
+  // Main
+  // -----------------------------------------------------------------
+  initial begin
+    init_signals();
+    do_reset();
+
+    test_io_01();
+    test_io_02();
+    test_io_03();
+    test_io_04();
+    test_io_05();
+    test_io_06();
+    test_io_07();
+    test_io_08();
+    test_io_09();
+    test_io_10();
+    test_io_11();
+    test_io_12();
+    test_io_13();
+    test_io_14();
+
+    repeat (4) @(posedge clk);
+    if (err_cnt == 0) begin
+      $display("");
+      $display("================================================");
+      $display("TEST PASSED  %0d / %0d checks", check_cnt, check_cnt);
+      $display("================================================");
+    end else begin
+      $display("");
+      $display("================================================");
+      $display("TEST FAILED  %0d errors / %0d checks", err_cnt, check_cnt);
+      $display("================================================");
+    end
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
## 変更内容

### RTL バグ修正

`rtl/io_controller.sv` のテストベンチ実装中に発見した unload パイプラインの制御バグを修正：

- **#26 unload 最初のワードが3回出力・末尾2ワード消失**: `unload_data_q` が StIoUnload 期間中に毎サイクル `mem_rdata_i` で上書きされ、`mem_addr_o` が出力カウンタ `word_cnt_q` でアドレス生成されていたため、BRAM 1cyc レイテンシと整合せず先頭ワードが3回連続出力されていた。読み出しアドレスカウンタ `read_cnt_q` を出力カウンタから分離し、`mem_re_q`（前サイクル発行フラグ）ベースのスキッド更新に変更。スキッドが空 or 出力受領時のみ次の読み出しを発行することで in-flight データ取りこぼしを防止。throughput は 1 word / 2 cycles（io_controller は外部 I/O 律速のため許容）。

### テストベンチ実装

- `tb/tb_io_controller.sv` — IO-01〜14 メイン TB
  - DUT に加え `operand_mem` を組み込み、Port A は DUT 駆動・Port B は TB の backdoor（unload 用 result 領域の事前ロード）
  - テストデータは `$urandom` で生成（io_controller はアドレッシングのみで値変換を伴わないため Python 参照モデル不要）

### TB 安全機構

- **タイムアウト**: `MAX_CYCLES = 200_000`。`always @(posedge clk)` 内でカウントし超過時に `$fatal`
- **VCD オプトイン**: 通常実行は VCD 生成なし。`vvp sim_io.out +vcd` でデバッグ時のみ生成

## 完了確認

- [x] 工程の成果物が `docs/`・`rtl/`・`tb/` に揃っている
- [x] 前工程の成果物（`docs/verification_spec.md` v1.7）との整合性を確認済み
- [x] `docs/verification_result.md` を更新（IO-01〜14 結果記録・発見バグ表追加）
- [x] バグ 1 件は Issue #26 に登録済み
- [x] Verible Lint クリア（`rtl/io_controller.sv`）

## 検証結果

\`\`\`
TEST PASSED  1988 / 1988 checks
\`\`\`

## 補足: IO-08 の解釈について

検証仕様 v1.7 の IO-08 は「addr_i=ParamP で 32 ワード unload」と記載されているが、設計仕様 §4.2 と RTL の `unload_num_words = 7'd64` 固定実装に従い「unload は addr_i に依らず 64 ワード（result 領域は常に 2048bit）」を実装意図として確認するテストに変更。仕様文言の更新は別途検討。

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)